### PR TITLE
Add AI Agent Bridge plugin

### DIFF
--- a/ai-agent-bridge/README.md
+++ b/ai-agent-bridge/README.md
@@ -1,0 +1,40 @@
+# AI Agent Bridge
+
+WordPress plugin exposing secure REST endpoints for external AI systems.
+
+## Installation
+1. Copy `ai-agent-bridge` to `wp-content/plugins/`.
+2. Activate via **Plugins**.
+3. Go to **Settings → AI Agent** and set the shared secret and optional IP allowlist.
+
+## Settings
+- **Shared Secret**: HS256 key for JWT.
+- **IP Allowlist**: comma separated list.
+- **Test Ping**: sends signed `/ping` request to verify setup.
+
+## Example Requests
+Replace `<TOKEN>` with a valid JWT signed using the shared secret.
+
+```
+# create post
+timestamp=$(date +%s)
+nonce=$(uuidgen)
+idem=$(uuidgen)
+curl -X POST https://example.com/wp-json/ai-agent/v1/posts \
+ -H "Authorization: Bearer <TOKEN>" \
+ -H "X-AI-Timestamp: $timestamp" \
+ -H "X-AI-Nonce: $nonce" \
+ -H "Idempotency-Key: $idem" \
+ -d '{"title":"Hi","content":"Hello"}'
+```
+
+## Error Codes
+| Code | Meaning |
+|------|---------|
+| `forbidden` | Auth, IP, timestamp or nonce invalid |
+| `rate_limited` | Too many requests |
+| `conflict` | Idempotency key reused |
+| `invalid` | Missing or bad input |
+
+## License
+GPL-2.0-or-later

--- a/ai-agent-bridge/admin/views/settings-page.php
+++ b/ai-agent-bridge/admin/views/settings-page.php
@@ -1,0 +1,29 @@
+<div class="wrap">
+<h1><?php echo esc_html__('AI Agent Bridge', 'ai-agent-bridge'); ?></h1>
+<form method="post" action="options.php">
+<?php settings_fields('ai_agent'); ?>
+<table class="form-table" role="presentation">
+<tr>
+<th scope="row"><label for="ai_agent_shared_secret"><?php _e('Shared Secret', 'ai-agent-bridge'); ?></label></th>
+<td><input type="text" name="ai_agent_shared_secret" id="ai_agent_shared_secret" value="<?php echo esc_attr(get_option('ai_agent_shared_secret')); ?>" class="regular-text" /></td>
+</tr>
+<tr>
+<th scope="row"><label for="ai_agent_ip_allowlist"><?php _e('IP Allowlist (comma separated)', 'ai-agent-bridge'); ?></label></th>
+<td><input type="text" name="ai_agent_ip_allowlist" id="ai_agent_ip_allowlist" value="<?php echo esc_attr(get_option('ai_agent_ip_allowlist')); ?>" class="regular-text" /></td>
+</tr>
+</table>
+<?php submit_button(); ?>
+</form>
+<button id="ai-agent-ping" class="button"><?php _e('Test Ping', 'ai-agent-bridge'); ?></button>
+<div id="ai-agent-ping-result"></div>
+</div>
+<script>
+(function($){
+    $('#ai-agent-ping').on('click', function(){
+        $('#ai-agent-ping-result').text('...');
+        $.post(ajaxurl, {action:'ai_agent_ping', _ajax_nonce:'<?php echo wp_create_nonce('ai_agent_ping'); ?>'}, function(r){
+            $('#ai-agent-ping-result').text(r.response ? r.response.message : 'error');
+        });
+    });
+})(jQuery);
+</script>

--- a/ai-agent-bridge/ai-agent-bridge.php
+++ b/ai-agent-bridge/ai-agent-bridge.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: AI Agent Bridge
+ * Description: Bridge for AI backend to manage content via signed requests.
+ * Version: 1.0.0
+ * Author: ChatGPT
+ * Text Domain: ai-agent-bridge
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('AI_AGENT_BRIDGE_VERSION', '1.0.0');
+define('AI_AGENT_BRIDGE_PATH', plugin_dir_path(__FILE__));
+define('AI_AGENT_BRIDGE_URL', plugin_dir_url(__FILE__));
+
+// load i18n
+function ai_agent_bridge_load_textdomain() {
+    load_plugin_textdomain('ai-agent-bridge', false, dirname(plugin_basename(__FILE__)) . '/languages');
+}
+add_action('plugins_loaded', 'ai_agent_bridge_load_textdomain');
+
+// includes
+require_once AI_AGENT_BRIDGE_PATH . 'includes/class-ai-agent-bridge-logger.php';
+require_once AI_AGENT_BRIDGE_PATH . 'includes/class-ai-agent-bridge-auth.php';
+require_once AI_AGENT_BRIDGE_PATH . 'includes/class-ai-agent-bridge-rest.php';
+require_once AI_AGENT_BRIDGE_PATH . 'includes/class-ai-agent-bridge-admin.php';
+
+// init
+add_action('init', function() {
+    AI_Agent_Bridge_REST::init();
+    AI_Agent_Bridge_Admin::init();
+});
+
+register_activation_hook(__FILE__, ['AI_Agent_Bridge_Logger', 'install']);

--- a/ai-agent-bridge/includes/class-ai-agent-bridge-admin.php
+++ b/ai-agent-bridge/includes/class-ai-agent-bridge-admin.php
@@ -1,0 +1,45 @@
+<?php
+class AI_Agent_Bridge_Admin {
+    public static function init() {
+        add_action('admin_menu', [__CLASS__, 'menu']);
+        add_action('admin_init', [__CLASS__, 'settings']);
+        add_action('wp_ajax_ai_agent_ping', [__CLASS__, 'ajax_ping']);
+    }
+
+    public static function menu() {
+        add_options_page('AI Agent', 'AI Agent', 'manage_options', 'ai-agent', [__CLASS__, 'page']);
+    }
+
+    public static function settings() {
+        register_setting('ai_agent', 'ai_agent_shared_secret');
+        register_setting('ai_agent', 'ai_agent_ip_allowlist');
+    }
+
+    public static function page() {
+        include AI_AGENT_BRIDGE_PATH . 'admin/views/settings-page.php';
+    }
+
+    public static function ajax_ping() {
+        check_ajax_referer('ai_agent_ping');
+        $secret = get_option('ai_agent_shared_secret');
+        if (!$secret) wp_send_json_error('no secret');
+        $header = self::b64url(json_encode(['alg' => 'HS256', 'typ' => 'JWT']));
+        $payload = self::b64url(json_encode(['iat' => time(), 'exp' => time() + 60]));
+        $sig = self::b64url(hash_hmac('sha256', "$header.$payload", $secret, true));
+        $token = "$header.$payload.$sig";
+        $args = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'X-AI-Timestamp' => time(),
+                'X-AI-Nonce' => wp_generate_uuid4(),
+                'Idempotency-Key' => wp_generate_uuid4(),
+            ],
+        ];
+        $res = wp_remote_get(rest_url('ai-agent/v1/ping'), $args);
+        wp_send_json($res['response']);
+    }
+
+    private static function b64url($data) {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/ai-agent-bridge/includes/class-ai-agent-bridge-auth.php
+++ b/ai-agent-bridge/includes/class-ai-agent-bridge-auth.php
@@ -1,0 +1,53 @@
+<?php
+class AI_Agent_Bridge_Auth {
+    private static function b64url_decode($data) {
+        return base64_decode(strtr($data, '-_', '+/'));
+    }
+
+    public static function verify_jwt($token, $secret) {
+        $parts = explode('.', $token);
+        if (count($parts) !== 3) return false;
+        list($h, $p, $s) = $parts;
+        $sig = self::b64url_decode($s);
+        $expected = hash_hmac('sha256', "$h.$p", $secret, true);
+        if (!hash_equals($expected, $sig)) return false;
+        $payload = json_decode(self::b64url_decode($p), true);
+        if (isset($payload['exp']) && time() >= $payload['exp']) return false;
+        return $payload;
+    }
+
+    public static function permission($request) {
+        $secret = get_option('ai_agent_shared_secret');
+        if (!$secret) return new WP_Error('forbidden', 'secret');
+
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $allow = get_option('ai_agent_ip_allowlist');
+        if ($allow) {
+            $list = array_map('trim', explode(',', $allow));
+            if (!in_array($ip, $list, true)) return new WP_Error('forbidden', 'ip');
+        }
+
+        $rate_key = 'ai_agent_rate_' . md5($ip);
+        $hits = (int)get_transient($rate_key);
+        if ($hits > 30) return new WP_Error('rate_limited', 'rate');
+        set_transient($rate_key, $hits + 1, MINUTE_IN_SECONDS);
+
+        $timestamp = (int)$request->get_header('x-ai-timestamp');
+        if (abs(time() - $timestamp) > 300) return new WP_Error('forbidden', 'ts');
+
+        $nonce = $request->get_header('x-ai-nonce');
+        if (!$nonce || get_transient('ai_agent_nonce_' . $nonce)) return new WP_Error('forbidden', 'nonce');
+        set_transient('ai_agent_nonce_' . $nonce, 1, 300);
+
+        $idem = $request->get_header('idempotency-key');
+        if ($idem && get_transient('ai_agent_idem_' . $idem)) return new WP_Error('conflict', 'idempotent');
+        if ($idem) set_transient('ai_agent_idem_' . $idem, 1, DAY_IN_SECONDS);
+
+        $auth = $request->get_header('authorization');
+        if (!preg_match('/Bearer\s+(.*)/', $auth, $m)) return new WP_Error('forbidden', 'auth');
+        $payload = self::verify_jwt(trim($m[1]), $secret);
+        if (!$payload) return new WP_Error('forbidden', 'jwt');
+
+        return true;
+    }
+}

--- a/ai-agent-bridge/includes/class-ai-agent-bridge-logger.php
+++ b/ai-agent-bridge/includes/class-ai-agent-bridge-logger.php
@@ -1,0 +1,20 @@
+<?php
+class AI_Agent_Bridge_Logger {
+    public static function install() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'ai_agent_logs';
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE $table (id BIGINT AUTO_INCREMENT PRIMARY KEY, action VARCHAR(100), data LONGTEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP) $charset;";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+    }
+
+    public static function log($action, $data = []) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'ai_agent_logs';
+        $wpdb->insert($table, [
+            'action' => $action,
+            'data' => wp_json_encode($data),
+        ]);
+    }
+}

--- a/ai-agent-bridge/includes/class-ai-agent-bridge-rest.php
+++ b/ai-agent-bridge/includes/class-ai-agent-bridge-rest.php
@@ -1,0 +1,100 @@
+<?php
+class AI_Agent_Bridge_REST {
+    public static function init() {
+        add_action('rest_api_init', [__CLASS__, 'register']);
+    }
+
+    public static function register() {
+        register_rest_route('ai-agent/v1', '/posts', [
+            'methods' => 'POST',
+            'permission_callback' => [AI_Agent_Bridge_Auth::class, 'permission'],
+            'callback' => [__CLASS__, 'create_post'],
+        ]);
+        register_rest_route('ai-agent/v1', '/posts/(?P<id>\d+)', [
+            'methods' => 'PUT',
+            'permission_callback' => [AI_Agent_Bridge_Auth::class, 'permission'],
+            'callback' => [__CLASS__, 'update_post'],
+        ]);
+        register_rest_route('ai-agent/v1', '/media', [
+            'methods' => 'POST',
+            'permission_callback' => [AI_Agent_Bridge_Auth::class, 'permission'],
+            'callback' => [__CLASS__, 'add_media'],
+        ]);
+        register_rest_route('ai-agent/v1', '/ping', [
+            'methods' => 'GET',
+            'permission_callback' => [AI_Agent_Bridge_Auth::class, 'permission'],
+            'callback' => [__CLASS__, 'ping'],
+        ]);
+        register_rest_route('ai-agent/v1', '/preview', [
+            'methods' => 'POST',
+            'permission_callback' => [AI_Agent_Bridge_Auth::class, 'permission'],
+            'callback' => [__CLASS__, 'preview_link'],
+        ]);
+        register_rest_route('ai-agent/v1', '/rollback', [
+            'methods' => 'POST',
+            'permission_callback' => [AI_Agent_Bridge_Auth::class, 'permission'],
+            'callback' => [__CLASS__, 'rollback'],
+        ]);
+    }
+
+    public static function create_post($request) {
+        $p = $request->get_json_params();
+        $post_id = wp_insert_post([
+            'post_title' => wp_strip_all_tags($p['title'] ?? ''),
+            'post_content' => $p['content'] ?? '',
+            'post_status' => $p['status'] ?? 'draft',
+        ]);
+        AI_Agent_Bridge_Logger::log('create', ['id' => $post_id]);
+        return ['id' => $post_id];
+    }
+
+    public static function update_post($request) {
+        $id = (int)$request['id'];
+        $p = $request->get_json_params();
+        $post_id = wp_update_post([
+            'ID' => $id,
+            'post_content' => $p['content'] ?? '',
+        ], true);
+        AI_Agent_Bridge_Logger::log('update', ['id' => $id]);
+        return ['id' => $post_id];
+    }
+
+    public static function add_media($request) {
+        $p = $request->get_json_params();
+        require_once ABSPATH . 'wp-admin/includes/media.php';
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+        if (!empty($p['url'])) {
+            $id = media_sideload_image(esc_url_raw($p['url']), 0, null, 'id');
+        } elseif (!empty($p['base64'])) {
+            $data = base64_decode($p['base64']);
+            $name = 'ai-' . time() . '.jpg';
+            $bits = wp_upload_bits($name, null, $data);
+            $file = $bits['file'];
+            $type = wp_check_filetype($file);
+            $id = wp_insert_attachment(['post_mime_type' => $type['type'], 'post_title' => $name], $file);
+            wp_update_attachment_metadata($id, wp_generate_attachment_metadata($id, $file));
+        } else {
+            return new WP_Error('invalid', 'no media');
+        }
+        AI_Agent_Bridge_Logger::log('media', ['id' => $id]);
+        return ['id' => (int)$id];
+    }
+
+    public static function ping() {
+        return ['pong' => time()];
+    }
+
+    public static function preview_link($request) {
+        $p = $request->get_json_params();
+        $link = get_preview_post_link((int)$p['post_id']);
+        return ['link' => $link];
+    }
+
+    public static function rollback($request) {
+        $p = $request->get_json_params();
+        $r = wp_restore_post_revision((int)$p['revision_id']);
+        AI_Agent_Bridge_Logger::log('rollback', $p);
+        return ['restored' => (bool)$r];
+    }
+}

--- a/ai-agent-bridge/languages/ai-agent-bridge.pot
+++ b/ai-agent-bridge/languages/ai-agent-bridge.pot
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: AI Agent Bridge 1.0.0\n"
+"POT-Creation-Date: 2024-06-14 00:00+0000\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Shared Secret"
+msgstr ""
+
+msgid "IP Allowlist (comma separated)"
+msgstr ""
+
+msgid "Test Ping"
+msgstr ""
+
+msgid "AI Agent Bridge"
+msgstr ""

--- a/ai-agent-bridge/readme.txt
+++ b/ai-agent-bridge/readme.txt
@@ -1,0 +1,23 @@
+=== AI Agent Bridge ===
+Contributors: chatgpt
+Tags: ai, rest, jwt
+Requires at least: 6.5
+Tested up to: 6.5
+Requires PHP: 8.1
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Bridge for AI backend to manage WordPress.
+
+== Description ==
+Secure REST endpoints for external AI agents to create and update content.
+
+== Installation ==
+1. Upload plugin files to `/wp-content/plugins/`.
+2. Activate plugin via Plugins menu.
+3. Set shared secret in Settings → AI Agent.
+
+== Changelog ==
+= 1.0.0 =
+* Initial release.


### PR DESCRIPTION
## Summary
- add AI Agent Bridge WordPress plugin exposing secure REST endpoints for posts, media, preview, rollback and ping
- implement JWT auth with nonce, timestamp, idempotency and rate limiting
- add admin settings page with shared secret, IP allowlist and test ping

## Testing
- `find ai-agent-bridge -name '*.php' -print | xargs -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6896af7c2cd083299a6b7c59d5202e0e